### PR TITLE
solved  석유시추 - 100.09ms 74.1mb

### DIFF
--- a/Programmers/석유시추/석유시추_허승경.java
+++ b/Programmers/석유시추/석유시추_허승경.java
@@ -1,0 +1,67 @@
+import java.util.*;
+
+public class Solution {
+    static class Point{
+        int x;
+        int y;
+
+        public Point(int x, int y){
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static boolean [][] visited;
+    static int [] memoization;
+    public static int solution(int[][] land) {
+        int answer = 0;
+        int n = land.length;
+        int m = land[0].length;
+        visited = new boolean[n][m];
+        memoization = new int[m];
+
+        for(int j = 0; j < m; j++){                 // 1. 영역 구하기
+            for(int i= 0; i < n; i++){
+                if(visited[i][j] || land[i][j] == 0) continue;
+                bfs(land, i, j);
+            }
+        }
+
+        for(int i = 0; i < m; i++){                // 2. 저장 된 값 중 최대 구하기
+            answer = Math.max(answer, memoization[i]);
+        }
+
+        return answer;
+    }
+    public static void bfs(int [][] land, int i, int j){
+        int n = land.length;
+        int m = land[0].length;
+        Queue<Point> que = new LinkedList<>();
+        Set<Integer> set = new LinkedHashSet<>();         // 현재의 석유 덩어리가 존재하는 열
+        que.add(new Point(i, j));
+        visited[i][j] = true;
+        int count = 1;
+        int [] dx = {-1, 0, 1, 0};
+        int [] dy = {0, 1, 0, -1};
+
+        while(!que.isEmpty()){
+            Point p = que.poll();
+            set.add(p.y);           // 현재의 석유 덩어리가 존재하는 열 추가
+
+            for (int k = 0; k < 4; k++) {
+                int tx = p.x + dx[k];
+                int ty = p.y + dy[k];
+
+                if (tx < 0 || tx >= n || ty < 0 || ty >= m) continue;
+                if (visited[tx][ty] || land[tx][ty] == 0) continue;
+                que.add(new Point(tx, ty));
+                visited[tx][ty] = true;
+                count++;
+            }
+        }
+        for(int current : set){
+            memoization[current] += count;          // 해당 열에 계속 더해나가기
+        }
+    }
+
+}


### PR DESCRIPTION
## 💿 풀이 문제
#142 

## 📝 풀이 후기
초기 풀이는 bfs 탐색시 중복이 많아 효율성 테스트에서 시간 초과가 발생했습니다.
열을 중심으로 bfs를 돌되, 한 구역에서 발생하는 석유의 양을 열마다 저장하여 해결했습니다.

## 📚 문제 풀이 핵심 키워드
- bfs
- memoization
- set
- visited를 전역으로 선언

## 🤔 리뷰로 궁금한 점
- 시간 초과가 발생하신 분들은 어떻게 해결하셨는지 궁금합니다~

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.