### PR TITLE
solved 석유시추 - 9ms 22mb

### DIFF
--- a/Programmers/석유시추/석유시추_조은영.cpp
+++ b/Programmers/석유시추/석유시추_조은영.cpp
@@ -1,0 +1,71 @@
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int dx[4] = { 0,0,1,-1 };
+int dy[4] = { 1,-1,0,0 };
+bool visited[500][500] = { false, };
+int landIdx[500][500];
+vector<int>landSize;
+int cnt = 0, idx = 0;
+
+bool isRange(int x, int y, int n, int m) {
+    return x >= 0 && x < n&& y >= 0 && y < m;
+}
+
+int DFS(int x, int y, vector<vector<int>>& land, int n, int m) {
+    int cnt = 1;
+    visited[x][y] = true;
+    landIdx[x][y] = idx;
+
+    for (int i = 0; i < 4; i++) {
+        int nextX = x + dx[i];
+        int nextY = y + dy[i];
+
+        // 범위 안이고 석유이고 방문하지 않았다면
+        if (isRange(nextX, nextY, n, m) && land[nextX][nextY] == 1 && !visited[nextX][nextY]) {
+            cnt += DFS(nextX, nextY, land, n, m);
+        }
+    }
+    return cnt;
+}
+
+int solution(vector<vector<int>> land) {
+
+    int answer = 0;
+    int n = land.size();
+    int m = land[0].size();
+
+    fill(&landIdx[0][0], &landIdx[0][0] + 500 * 500, -1);
+
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < m; j++) {
+            // 석유가 있고 아직 방문 안했다면
+            if (land[i][j] == 1 && !visited[i][j]) {
+                int res = DFS(i, j, land, n, m);
+                landSize.push_back(res);
+                idx++;
+            }
+        }
+
+    }
+
+    // 시추하기
+    // 열 - 행 순으로 탐색
+    for (int j = 0; j < m; j++) {
+        int sum = 0;
+        vector<bool>landVisited(landSize.size(), false);
+        for (int i = 0; i < n; i++) {
+            int value = landIdx[i][j];
+            if (value != -1 && !landVisited[value]) {
+                landVisited[value] = true;
+                sum += landSize[value];
+            }
+        }
+        answer = max(answer, sum);
+    }
+
+    return answer;
+}


### PR DESCRIPTION
## 💿 풀이 문제
#142 

## 📝 풀이 후기
시간복잡도를 고려해야했지만 평이했습니다. 백준에 있는 다리만들기가 생각나는 문제였네요.

## 📚 문제 풀이 핵심 키워드
- 가장 먼저 생각난 아이디어는 열부터 탐색하며 열이 변경될 때마다 DFS또는 BFS로 덩어리 크기를 구하고 최대값을 갱신해주는 것이었습니다. 하지만 이렇게 할 경우 불필요하게 많은 탐색이 일어나고 열이 바뀔때마다 visited 배열을 초기화해야합니다. 이 과정에서 n*m*n*m의 시간복잡도가 발생하여 효율성 테스트를 통과할 수 없습니다.
- 따라서 땅을 먼저 탐색한 후 시추하는 방법을 썼습니다. 덩어리에 인덱스를 붙여주고 한 덩어리 탐색이 끝날때마다 덩어리 크기를 저장합니다. 이렇게 하면 landSize[덩어리 인덱스]로 덩어리 크기를 구할 수 있고, visited[덩어리 인덱스]로 이미 시추한 덩어리를 다시 시추하지 않게 할 수 있습니다.

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
<!-- Merge가 되면, Branch를 꼭 삭제해주세요 -->
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
<!-- 코드리뷰를 신청하지 않은 인원은 '리뷰어 확인 사항'을 모두 삭제해주세요. -->
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.