### PR TITLE
solved 석유시추-5.24ms 14.1MB

### DIFF
--- a/Programmers/석유시추/석유시추_여동훈.cpp
+++ b/Programmers/석유시추/석유시추_여동훈.cpp
@@ -1,0 +1,53 @@
+#include <string>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int solution(vector<vector<int>> land) {
+    int answer = 0;
+    int R = land.size();
+    int C = land[0].size();
+    int dy[] = {-1,0,1,0};
+    int dx[] = {0,1,0,-1};
+    vector<vector<int>> visited(R, vector<int>(C,0));
+    vector<vector<int>> ans(C);
+    for(int i =0 ; i< R ;i++){
+        for(int j = 0 ; j< C; j++){
+            if(visited[i][j]) continue;
+            if(land[i][j]==0) continue;
+            int minx= j, maxx= j;
+            visited[i][j] = 1;
+            queue<pair<int,int>> q;
+            q.push({i,j});
+            int oil_size = 1;
+            while(!q.empty()){
+                pair<int,int> now = q.front(); q.pop();
+                for(int i = 0 ; i< 4; i++){
+                    int ny = now.first + dy[i];
+                    int nx = now.second + dx[i];
+                    if(ny >= R || nx >= C || ny <0 || nx < 0) continue;
+                    if(visited[ny][nx]) continue;
+                    if(land[ny][nx] == 0) continue;
+                    visited[ny][nx] =1;
+                    oil_size++;
+                    minx = minx > nx ? nx : minx;
+                    maxx = maxx < nx ? nx : maxx;
+                    q.push({ny,nx});
+                }
+            }    
+            for(int k = minx; k<= maxx; k++){
+                ans[k].push_back(oil_size);
+            }
+        }
+    }
+    for(int i = 0; i< C; i++){
+        int sum =0;
+        for(auto n : ans[i]){
+            sum += n;
+        }
+        answer = answer < sum ? sum : answer;
+    }
+    
+    return answer;
+}


### PR DESCRIPTION
## 💿 풀이 문제
#142

## 📝 풀이 후기
시간복잡도를 고려 하는게 어려웠습니다.

## 📚 문제 풀이 핵심 키워드
BFS, DFS 둘중 하나를 써도 무방합니다.
visited 배열로 석유 덩어리 별로 인덱스를 만든 후 인덱스 별 덩어리 갯수를 메모하고, 열을 탐색하면서 중복된 인덱스 제외 및 합계를 구해 최종으로 최댓값을 구하는 방법을 쓰니 25ms 이상으로 나와 처음에 실패했습니다.

석유의 크기를 저장하는 x열 벡터를 생성하고, 덩어리를 탐색할때 덩어리의 최소 x값, 최대 x값을 찾아 최소~ 최대 x 부분에 해당하는 x열 벡터에 석유의 크기를 차례로 넣어줍니다. 이미 탐색된 석유덩어리는 더 이상 탐색 하지 않으므로, 중복적으로 x열벡터에 같은 덩어리가 들어갈 일이 생기지 않습니다. 이렇게 하니 5ms로 통과했습니다.

## 🤔 리뷰로 궁금한 점
<!-- 확인받고 싶은 기준을 작성해주시면 좋습니다. -->
<!-- 운영자에게 리뷰를 받고 싶다면, Reviewer에 @hadevyi를 태그해주세요. -->

## 🧑‍💻 제출자 확인 사항
<!-- Merge가 되면, Branch를 꼭 삭제해주세요 -->
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
<!-- 코드리뷰를 신청하지 않은 인원은 '리뷰어 확인 사항'을 모두 삭제해주세요. -->
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.